### PR TITLE
[MI-3194] Fix issue: getting multiple users with same email address.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ jar {
 }
 
 group = 'com.brightscout'
-version = '2.3.5'
+version = '2.3.6'
 sourceCompatibility = '11'
 
 repositories {

--- a/src/main/java/com/brightscout/ews/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/brightscout/ews/service/impl/UserServiceImpl.java
@@ -13,6 +13,7 @@ import com.brightscout.ews.service.UserService;
 import com.brightscout.ews.utils.AppConstants;
 
 import microsoft.exchange.webservices.data.core.ExchangeService;
+import microsoft.exchange.webservices.data.core.enumeration.search.ResolveNameSearchLocation;
 import microsoft.exchange.webservices.data.misc.NameResolution;
 import microsoft.exchange.webservices.data.misc.NameResolutionCollection;
 
@@ -25,7 +26,7 @@ public class UserServiceImpl implements UserService {
 	public ResponseEntity<User> getUser(ExchangeService service, String email) throws InternalServerException {
 		logger.debug("Getting user details for user: {}", email);
 		try {
-			NameResolutionCollection resolvedNames = service.resolveName(email);
+			NameResolutionCollection resolvedNames = service.resolveName(email, ResolveNameSearchLocation.DirectoryOnly, false);
 
 			if (resolvedNames.getCount() == 0) {
 				throw new InternalServerException(


### PR DESCRIPTION
Reason:
We were searching in the directory as well as the user's contacts. Now we are searching only in the active directory.

Bump plugin version to v2.3.6
Release notes:
1. Fixed issue: getting multiple users with same email address from ews API.
